### PR TITLE
Release 1.0.0: tests, readme, context regions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,7 +56,7 @@
     <!-- CA1812: False positives for DI-instantiated classes -->
     <!-- IL2026, IL2067, IL2070, IL2075, IL3050, IL2104, IL3053: AOT warnings (not yet implemented) -->
     <!-- IDE0290: Use primary constructor - disabled per project preference -->
-    <NoWarn>$(NoWarn);CA1014;CA1724;CA1812;IDE0290;IL2026;IL2067;IL2070;IL2075;IL3050;IL2104;IL3053</NoWarn>
+    <NoWarn>$(NoWarn);CA1014;CA1724;CA1812;IDE0290</NoWarn>
   </PropertyGroup>
 
   <!-- Code analyzers applied to all projects -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,15 +5,19 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="TimeWarp Packages">
-    <PackageVersion Include="TimeWarp.Amuru" Version="1.0.0-beta.33" />
+    <PackageVersion Include="TimeWarp.Amuru" Version="1.0.0-beta.34" />
     <PackageVersion Include="TimeWarp.Nuru" Version="3.0.0-beta.71" />
     <PackageVersion Include="TimeWarp.Build.Tasks" Version="1.0.0" />
+    <PackageVersion Include="TimeWarp.Jaribu" Version="1.0.0-beta.13" />
+  </ItemGroup>
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Label="Code Analyzers">
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.300" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
   </ItemGroup>

--- a/kanban/in-progress/001-address-code-review-blockers-for-v100-release.md
+++ b/kanban/in-progress/001-address-code-review-blockers-for-v100-release.md
@@ -16,8 +16,10 @@ Code review report: `.agent/workspace/2026-02-23T00-00-00_code-review-release-re
   - Add `ToolsDirectory` for future tooling support
   - Note: TestsDirectory, SamplesDirectory, BenchmarksDirectory left in place for future use
 
-- [ ] **Add automated tests**
-  - Create test project (suggested: `tests/TimeWarp.Builder.Tests/`)
+- [x] **Add automated tests** (2026-07-02)
+  - Implemented as TimeWarp.Jaribu runfiles under `tests/` (repo convention) rather than a dotnet-test project; `dev test` runs each runfile and aggregates exit codes
+  - 21 tests across 6 files: 4 scope-extension files + 2 interface integration files (concrete builders modeled on TimeWarp.Nuru's usage), covering null guards and covariance
+  - Original scope:
   - Test all 4 scope extension methods:
     - `Also` - executes action, returns original object
     - `Apply` - executes action, returns original object
@@ -37,7 +39,7 @@ Code review report: `.agent/workspace/2026-02-23T00-00-00_code-review-release-re
 
 ### ⚠️ High Priority (strongly recommended)
 
-- [ ] **Improve README.md**
+- [x] **Improve README.md** (2026-07-02)
   - Add installation section with `dotnet add package TimeWarp.Builder`
   - Add requirements section (target framework: .NET 10.0)
   - Add license badge and link to LICENSE file
@@ -45,7 +47,8 @@ Code review report: `.agent/workspace/2026-02-23T00-00-00_code-review-release-re
   - Add design rationale explaining `Also` vs `Apply` distinction
   - Link to GitHub repository
 
-- [ ] **Wire up package icon**
+- [x] **Wire up package icon** — resolved with `logo.png` in `source/Directory.Build.props`; ganda's nuget-package-icon audit check passes
+  - Original suggestion:
   - Add `<PackageIcon>timewarp-builder-avatar.png</PackageIcon>` (convert SVG to PNG if needed, NuGet prefers PNG)
   - Add icon file reference to `.csproj`:
     ```xml
@@ -55,7 +58,7 @@ Code review report: `.agent/workspace/2026-02-23T00-00-00_code-review-release-re
     ```
   - Note: `assets/timewarp-builder-avatar.svg` exists but SVG icons in NuGet packages have limited client support
 
-- [ ] **Prune `Directory.Packages.props`**
+- [x] **Prune `Directory.Packages.props`** (2026-07-02, ganda audit CPM cleanup; Jaribu/Shouldly re-added for tests)
   - Remove unused package groups:
     - Serilog (Logging - Serilog section)
     - OpenTelemetry
@@ -67,14 +70,15 @@ Code review report: `.agent/workspace/2026-02-23T00-00-00_code-review-release-re
   - Keep only packages actually referenced by this library (likely just analyzers and Microsoft.Extensions if needed)
   - Note: `TimeWarp.Builder` self-reference can also be removed
 
-- [ ] **Review AOT warning suppressions**
+- [x] **Review AOT warning suppressions** (2026-07-02) — removed all seven IL* suppressions; both the library build and the dev-cli AOT publish verified clean without them
+  - Original scope:
   - Current global suppressions in `Directory.Build.props`: `IL2026;IL2067;IL2070;IL2075;IL3050;IL2104;IL3053`
   - Evaluate if these are truly needed for this library (it has no reflection/dynamic code)
   - If they are false positives, consider removing the global suppression and testing AOT build
 
 ### Nice to Have (low priority)
 
-- [ ] Add `#region Purpose` / `#region Design` context blocks to source files per csharp skill conventions
+- [x] Add `#region Purpose` / `#region Design` context blocks to source files per csharp skill conventions (2026-07-02)
 - [ ] Add `CHANGELOG.md` for v1.0.0 release notes
 - [ ] Consider `IBuildAsync<T>` interface for async build scenarios (future v1.x)
 

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,28 @@
 # TimeWarp.Builder
 
+[![NuGet](https://img.shields.io/nuget/vpre/TimeWarp.Builder.svg)](https://www.nuget.org/packages/TimeWarp.Builder)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/TimeWarp.Builder.svg)](https://www.nuget.org/packages/TimeWarp.Builder)
+[![CI/CD](https://github.com/TimeWarpEngineering/timewarp-builder/actions/workflows/workflow.yml/badge.svg)](https://github.com/TimeWarpEngineering/timewarp-builder/actions/workflows/workflow.yml)
+[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
+
 Fluent builder interfaces and Kotlin-inspired scope extensions for .NET.
+
+## Installation
+
+```bash
+dotnet add package TimeWarp.Builder --prerelease
+```
+
+## Requirements
+
+- .NET 10.0 or later
+- Fully AOT- and trim-compatible (no reflection, no dynamic code)
 
 ## Interfaces
 
 ### IBuilder\<T\>
 
-Interface for standalone builders that create objects via `Build()`.
+Interface for standalone builders that create objects via `Build()`. `TBuilt` is covariant, so an `IBuilder<Derived>` can be used wherever an `IBuilder<Base>` is expected.
 
 ```csharp
 public class MyWidgetBuilder : IBuilder<Widget>
@@ -23,7 +39,7 @@ Widget widget = new MyWidgetBuilder()
 
 ### INestedBuilder\<TParent\>
 
-Interface for nested builders that return to a parent context via `Done()`.
+Interface for nested builders that return to a parent context via `Done()`. `Done()` performs three things: builds the child, hands the result to the parent, and returns the parent for continued chaining.
 
 ```csharp
 // Nested builder returns to parent after building
@@ -36,21 +52,38 @@ app.Map(route => route
 
 ## Scope Extensions
 
-Kotlin-inspired extension methods for fluent object manipulation.
+Kotlin-inspired extension methods for fluent object manipulation. Because they attach to every type (unconstrained `T`), any object can participate in a fluent chain without its type opting in.
+
+| Method | Returns | Use for |
+|--------|---------|---------|
+| `Also` | The original object | Side effects mid-chain (logging, diagnostics) |
+| `Apply` | The original object | Configuring the object mid-chain |
+| `Let` | The transform result | Converting to a different type/value |
+| `Run` | Nothing (`void`) | Terminal action at the end of a chain |
+
+### Also vs Apply
+
+`Also` and `Apply` are mechanically identical — both execute an action and return the original object. They exist separately to signal *intent* at the call site, mirroring Kotlin's `also`/`apply` distinction: use `Apply` when the action configures the object itself, and `Also` when the action is an incidental side effect like logging.
+
+```csharp
+app.Map("status", handler)
+   .Apply(r => r.AsQuery())                        // configures the route
+   .Also(r => logger.LogDebug("mapped {r}", r));   // side effect, not configuration
+```
 
 ### Also
 
-Executes an action on the object and returns the original object. Useful for side effects during method chaining.
+Executes an action on the object and returns the original object.
 
 ```csharp
 var builder = new AppBuilder()
-    .Also(b => Console.WriteLine("Building app..."))
+    .Also(b => logger.LogDebug("Building app..."))
     .Configure(options);
 ```
 
 ### Apply
 
-Configures the object and returns the original object. Semantically similar to `Also` but with clearer intent for configuration.
+Configures the object and returns the original object.
 
 ```csharp
 app.Map("status", handler)
@@ -72,3 +105,22 @@ Executes an action on the object with no return value. Terminal operation in a m
 ```csharp
 app.Build().Run(a => a.RunAsync(args));
 ```
+
+All four methods throw `ArgumentNullException` when the delegate is null.
+
+## Used By
+
+- [TimeWarp.Nuru](https://github.com/TimeWarpEngineering/timewarp-nuru) — route, endpoint, group, and key-binding builders implement `IBuilder<T>` / `INestedBuilder<TParent>`
+- [TimeWarp.Terminal](https://github.com/TimeWarpEngineering/timewarp-terminal)
+
+## Testing
+
+Tests are [TimeWarp.Jaribu](https://github.com/TimeWarpEngineering/timewarp-jaribu) runfiles under `tests/`. Run them all with `dev test`, or any file directly:
+
+```bash
+dotnet run tests/scope-extensions.also.cs
+```
+
+## Unlicense
+
+This is free and unencumbered software released into the public domain — see [LICENSE](LICENSE).

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>1.0.0-beta.3</Version>
+    <Version>1.0.0</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-builder</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/source/timewarp-builder/global-usings.cs
+++ b/source/timewarp-builder/global-usings.cs
@@ -1,1 +1,5 @@
+#region Purpose
+// Global using directives for the TimeWarp.Builder library.
+#endregion
+
 global using System;

--- a/source/timewarp-builder/i-builder.cs
+++ b/source/timewarp-builder/i-builder.cs
@@ -1,3 +1,13 @@
+#region Purpose
+// Contract for standalone builders that produce their configured object via Build().
+#endregion
+
+#region Design
+// TBuilt is covariant (out) so an IBuilder<Derived> is usable where an IBuilder<Base> is
+// expected. Builders that finish by returning to a parent context instead implement
+// INestedBuilder<TParent>; the two interfaces are intentionally minimal and independent.
+#endregion
+
 namespace TimeWarp.Builder;
 
 /// <summary>

--- a/source/timewarp-builder/i-nested-builder.cs
+++ b/source/timewarp-builder/i-nested-builder.cs
@@ -1,3 +1,14 @@
+#region Purpose
+// Contract for nested builders that finish via Done() and return control to a parent builder.
+#endregion
+
+#region Design
+// Done() bundles three steps: build the child, hand the result to the parent, return the
+// parent — enabling deep fluent chains without the caller juggling intermediate results.
+// TParent is covariant (out) and constrained to class; nested builders typically wrap a
+// standalone IBuilder<TBuilt> internally (see TimeWarp.Nuru's NestedCompiledRouteBuilder).
+#endregion
+
 namespace TimeWarp.Builder;
 
 /// <summary>

--- a/source/timewarp-builder/scope-extensions.cs
+++ b/source/timewarp-builder/scope-extensions.cs
@@ -1,3 +1,15 @@
+#region Purpose
+// Kotlin-inspired scope extension methods (Also, Apply, Let, Run) for fluent object manipulation.
+#endregion
+
+#region Design
+// Also and Apply share an implementation; they exist separately to signal intent at the call
+// site (Apply = configuration, Also = incidental side effect), mirroring Kotlin's apply/also.
+// T is deliberately unconstrained so the extensions attach to every type — any object can join
+// a fluent chain without its type opting in; the IntelliSense noise is the accepted trade-off.
+// Delegates are null-guarded; the receiver is not, matching BCL extension-method convention.
+#endregion
+
 namespace TimeWarp.Builder;
 
 /// <summary>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+  <!-- Import parent Directory.Build.props -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Test idioms that conflict with the library-grade analyzer settings -->
+    <!-- CA1707: Underscores in names - required by the Jaribu naming convention -->
+    <!-- CA1515/CA1812: Public/uninstantiated types - Jaribu discovers tests via reflection -->
+    <!-- CA2007: ConfigureAwait not needed in test runfiles -->
+    <!-- CS1591: XML doc comments not required for tests -->
+    <!-- CA1859: Prefer concrete types - covariance tests intentionally use interface-typed variables -->
+    <!-- CA1861: Inline array literals in assertions - test readability over allocation -->
+    <!-- IDE0058: Discarded expression values - fluent assertions and chained calls -->
+    <!-- IDE0210/IDE0211: Runfiles must use top-level statements -->
+    <!-- RCS1046: Async suffix not used in test method names -->
+    <NoWarn>$(NoWarn);CA1707;CA1515;CA1812;CA1859;CA1861;CA2007;CS1591;IDE0058;IDE0210;IDE0211;RCS1046</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Global usings for Jaribu test runfiles -->
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Runtime.CompilerServices" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="Shouldly" />
+    <Using Include="TimeWarp.Builder" />
+    <Using Include="TimeWarp.Jaribu" />
+    <Using Include="TimeWarp.Jaribu.TestRunner" Static="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TimeWarp.Jaribu" />
+    <PackageReference Include="Shouldly" />
+    <ProjectReference Include="$(RepositoryRoot)source/timewarp-builder/timewarp-builder.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/i-builder.build.cs
+++ b/tests/i-builder.build.cs
@@ -1,0 +1,74 @@
+#!/usr/bin/env -S dotnet --
+
+#region Purpose
+// Tests for IBuilder<TBuilt>: standalone builders produce their configured object via Build().
+#endregion
+
+#if !JARIBU_MULTI
+return await RunAllTests();
+#endif
+
+namespace IBuilder_
+{
+  [TestTag("Interfaces")]
+  public sealed class Build_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Build_Given_>();
+
+    public static async Task ConcreteBuilder_Should_ReturnConfiguredObject()
+    {
+      Widget widget = new WidgetBuilder()
+        .WithName("gizmo")
+        .WithSize(10)
+        .Build();
+
+      widget.Name.ShouldBe("gizmo");
+      widget.Size.ShouldBe(10);
+      await Task.CompletedTask;
+    }
+
+    public static async Task CovariantTBuilt_Should_AssignToBaseTypedInterface()
+    {
+      // IBuilder<out TBuilt> covariance: a Widget builder is usable where an object builder is expected
+      IBuilder<object> builder = new WidgetBuilder().WithName("gizmo");
+
+      builder.Build().ShouldBeOfType<Widget>();
+      await Task.CompletedTask;
+    }
+
+    public static async Task RepeatedBuild_Should_ProduceIndependentObjects()
+    {
+      WidgetBuilder builder = new WidgetBuilder().WithName("gizmo");
+
+      Widget first = builder.Build();
+      Widget second = builder.Build();
+
+      first.ShouldNotBeSameAs(second);
+      first.ShouldBe(second);
+      await Task.CompletedTask;
+    }
+  }
+
+  internal sealed record Widget(string Name, int Size);
+
+  internal sealed class WidgetBuilder : IBuilder<Widget>
+  {
+    private string Name = "";
+    private int Size;
+
+    public WidgetBuilder WithName(string name)
+    {
+      Name = name;
+      return this;
+    }
+
+    public WidgetBuilder WithSize(int size)
+    {
+      Size = size;
+      return this;
+    }
+
+    public Widget Build() => new(Name, Size);
+  }
+}

--- a/tests/i-nested-builder.done.cs
+++ b/tests/i-nested-builder.done.cs
@@ -1,0 +1,113 @@
+#!/usr/bin/env -S dotnet --
+
+#region Purpose
+// Tests for INestedBuilder<TParent>: nested builders build their child, hand it to the
+// parent, and return the parent via Done() for continued fluent chaining.
+#endregion
+
+#if !JARIBU_MULTI
+return await RunAllTests();
+#endif
+
+namespace INestedBuilder_
+{
+  [TestTag("Interfaces")]
+  public sealed class Done_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Done_Given_>();
+
+    public static async Task NestedBuilder_Should_ReturnParentInstance()
+    {
+      RobotBuilder parent = new();
+
+      RobotBuilder returned = parent.AddArm(arm => arm.WithLength(2).Done());
+
+      returned.ShouldBeSameAs(parent);
+      await Task.CompletedTask;
+    }
+
+    public static async Task Done_Should_PassBuiltChildToParent()
+    {
+      Robot robot = new RobotBuilder()
+        .AddArm(arm => arm.WithLength(2).Done())
+        .AddArm(arm => arm.WithLength(3).Done())
+        .Build();
+
+      robot.Arms.Count.ShouldBe(2);
+      robot.Arms[0].Length.ShouldBe(2);
+      robot.Arms[1].Length.ShouldBe(3);
+      await Task.CompletedTask;
+    }
+
+    public static async Task CovariantTParent_Should_AssignToBaseTypedInterface()
+    {
+      // INestedBuilder<out TParent> covariance: a RobotBuilder-parented nested builder is
+      // usable where an object-parented one is expected
+      RobotBuilder parent = new();
+      INestedBuilder<object> nested = new NestedArmBuilder<RobotBuilder>(parent, _ => { });
+
+      nested.Done().ShouldBeSameAs(parent);
+      await Task.CompletedTask;
+    }
+
+    public static async Task FluentChain_Should_ComposeWithScopeExtensions()
+    {
+      List<int> observedLengths = [];
+
+      Robot robot = new RobotBuilder()
+        .AddArm(arm => arm.WithLength(5).Done())
+        .Also(builder => builder.AddArm(arm => arm.WithLength(7).Done()))
+        .Build()
+        .Apply(built => observedLengths.AddRange(built.Arms.Select(a => a.Length)));
+
+      robot.Arms.Count.ShouldBe(2);
+      observedLengths.ShouldBe(new[] { 5, 7 });
+      await Task.CompletedTask;
+    }
+  }
+
+  internal sealed record Arm(int Length);
+
+  internal sealed record Robot(IReadOnlyList<Arm> Arms);
+
+  // Mirrors the pattern used by TimeWarp.Nuru's NestedCompiledRouteBuilder<TParent>:
+  // wraps the child state, and Done() = build child + hand to parent + return parent.
+  internal sealed class NestedArmBuilder<TParent> : INestedBuilder<TParent> where TParent : class
+  {
+    private readonly TParent Parent;
+    private readonly Action<Arm> OnBuilt;
+    private int Length;
+
+    public NestedArmBuilder(TParent parent, Action<Arm> onBuilt)
+    {
+      Parent = parent;
+      OnBuilt = onBuilt;
+    }
+
+    public NestedArmBuilder<TParent> WithLength(int length)
+    {
+      Length = length;
+      return this;
+    }
+
+    public TParent Done()
+    {
+      OnBuilt(new Arm(Length));
+      return Parent;
+    }
+  }
+
+  internal sealed class RobotBuilder : IBuilder<Robot>
+  {
+    private readonly List<Arm> Arms = [];
+
+    public RobotBuilder AddArm(Func<NestedArmBuilder<RobotBuilder>, RobotBuilder> configure)
+    {
+      ArgumentNullException.ThrowIfNull(configure);
+      return configure(new NestedArmBuilder<RobotBuilder>(this, Arms.Add));
+    }
+
+    public Robot Build() => new([.. Arms]);
+  }
+}

--- a/tests/scope-extensions.also.cs
+++ b/tests/scope-extensions.also.cs
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S dotnet --
+
+#region Purpose
+// Tests for ScopeExtensions.Also: executes a side effect and returns the original object.
+#endregion
+
+#if !JARIBU_MULTI
+return await RunAllTests();
+#endif
+
+namespace ScopeExtensions_
+{
+  [TestTag("ScopeExtensions")]
+  public sealed class Also_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Also_Given_>();
+
+    public static async Task ReferenceType_Should_ExecuteActionAndReturnSameInstance()
+    {
+      List<string> subject = [];
+
+      List<string> result = subject.Also(list => list.Add("side effect"));
+
+      result.ShouldBeSameAs(subject);
+      subject.ShouldContain("side effect");
+      await Task.CompletedTask;
+    }
+
+    public static async Task ChainedCalls_Should_ExecuteActionsInOrder()
+    {
+      List<int> executionOrder = [];
+
+      string result = "subject"
+        .Also(_ => executionOrder.Add(1))
+        .Also(_ => executionOrder.Add(2));
+
+      result.ShouldBe("subject");
+      executionOrder.ShouldBe(new[] { 1, 2 });
+      await Task.CompletedTask;
+    }
+
+    public static async Task ValueType_Should_ReturnOriginalValue()
+    {
+      int result = 42.Also(_ => { });
+
+      result.ShouldBe(42);
+      await Task.CompletedTask;
+    }
+
+    public static async Task NullAction_Should_ThrowArgumentNullException()
+    {
+      Should.Throw<ArgumentNullException>(() => "subject".Also(null!));
+      await Task.CompletedTask;
+    }
+  }
+}

--- a/tests/scope-extensions.apply.cs
+++ b/tests/scope-extensions.apply.cs
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S dotnet --
+
+#region Purpose
+// Tests for ScopeExtensions.Apply: configures the object and returns the original object.
+#endregion
+
+#if !JARIBU_MULTI
+return await RunAllTests();
+#endif
+
+namespace ScopeExtensions_
+{
+  [TestTag("ScopeExtensions")]
+  public sealed class Apply_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Apply_Given_>();
+
+    public static async Task MutableObject_Should_ConfigureAndReturnSameInstance()
+    {
+      Options subject = new();
+
+      Options result = subject.Apply(options => options.Name = "configured");
+
+      result.ShouldBeSameAs(subject);
+      subject.Name.ShouldBe("configured");
+      await Task.CompletedTask;
+    }
+
+    public static async Task MidChainConfiguration_Should_PreserveFluentFlow()
+    {
+      List<string> log = [];
+
+      Options result = new Options()
+        .Apply(options => options.Name = "first")
+        .Also(options => log.Add(options.Name))
+        .Apply(options => options.Name = "second");
+
+      result.Name.ShouldBe("second");
+      log.ShouldBe(new[] { "first" });
+      await Task.CompletedTask;
+    }
+
+    public static async Task NullAction_Should_ThrowArgumentNullException()
+    {
+      Should.Throw<ArgumentNullException>(() => new Options().Apply(null!));
+      await Task.CompletedTask;
+    }
+  }
+
+  internal sealed class Options
+  {
+    public string Name { get; set; } = "";
+  }
+}

--- a/tests/scope-extensions.let.cs
+++ b/tests/scope-extensions.let.cs
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S dotnet --
+
+#region Purpose
+// Tests for ScopeExtensions.Let: transforms the object to a different type or value.
+#endregion
+
+#if !JARIBU_MULTI
+return await RunAllTests();
+#endif
+
+namespace ScopeExtensions_
+{
+  [TestTag("ScopeExtensions")]
+  public sealed class Let_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Let_Given_>();
+
+    public static async Task String_Should_TransformToDifferentType()
+    {
+      int length = "hello".Let(s => s.Length);
+
+      length.ShouldBe(5);
+      await Task.CompletedTask;
+    }
+
+    public static async Task ValueType_Should_TransformValue()
+    {
+      int doubled = 21.Let(x => x * 2);
+
+      doubled.ShouldBe(42);
+      await Task.CompletedTask;
+    }
+
+    public static async Task ChainedTransforms_Should_ComposeLeftToRight()
+    {
+      string result = 7
+        .Let(x => x * 10)
+        .Let(x => $"value-{x}");
+
+      result.ShouldBe("value-70");
+      await Task.CompletedTask;
+    }
+
+    public static async Task NullTransform_Should_ThrowArgumentNullException()
+    {
+      Should.Throw<ArgumentNullException>(() => "subject".Let((Func<string, int>)null!));
+      await Task.CompletedTask;
+    }
+  }
+}

--- a/tests/scope-extensions.run.cs
+++ b/tests/scope-extensions.run.cs
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S dotnet --
+
+#region Purpose
+// Tests for ScopeExtensions.Run: executes a terminal action on the object with no return value.
+#endregion
+
+#if !JARIBU_MULTI
+return await RunAllTests();
+#endif
+
+namespace ScopeExtensions_
+{
+  [TestTag("ScopeExtensions")]
+  public sealed class Run_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Run_Given_>();
+
+    public static async Task Object_Should_ExecuteActionWithReceiver()
+    {
+      string? observed = null;
+
+      "subject".Run(s => observed = s);
+
+      observed.ShouldBe("subject");
+      await Task.CompletedTask;
+    }
+
+    public static async Task EndOfChain_Should_ActAsTerminalOperation()
+    {
+      List<string> log = [];
+
+      "subject"
+        .Also(_ => log.Add("first"))
+        .Run(_ => log.Add("terminal"));
+
+      log.ShouldBe(new[] { "first", "terminal" });
+      await Task.CompletedTask;
+    }
+
+    public static async Task NullAction_Should_ThrowArgumentNullException()
+    {
+      Should.Throw<ArgumentNullException>(() => "subject".Run(null!));
+      await Task.CompletedTask;
+    }
+  }
+}

--- a/tools/dev-cli/endpoints/test.cs
+++ b/tools/dev-cli/endpoints/test.cs
@@ -4,7 +4,13 @@
 // Runs the test suite for TimeWarp.Builder.
 
 #region Purpose
-// 'dev test' endpoint: runs the solution test suite, skipping gracefully when tests/ is absent.
+// 'dev test' endpoint: runs each Jaribu test runfile under tests/, skipping gracefully when none exist.
+#endregion
+
+#region Design
+// Tests are standalone Jaribu runfiles (see the jaribu skill), not dotnet-test projects,
+// so each *.cs under tests/ is executed via 'dotnet run' and exit codes are aggregated.
+// --filter maps to the JARIBU_FILTER_TAG environment variable Jaribu uses for tag filtering.
 #endregion
 
 namespace DevCli.Commands;
@@ -15,14 +21,8 @@ namespace DevCli.Commands;
 [NuruRoute("test", Description = "Run the test suite")]
 internal sealed class TestCommand : ICommand<Unit>
 {
-  [Option("filter", "f", Description = "Test filter expression")]
+  [Option("filter", "f", Description = "Jaribu tag filter (sets JARIBU_FILTER_TAG)")]
   public string? Filter { get; set; }
-
-  [Option("no-build", null, Description = "Skip build before testing")]
-  public bool NoBuild { get; set; }
-
-  [Option("verbose", "v", Description = "Verbose output")]
-  public bool Verbose { get; set; }
 
   internal sealed class Handler : ICommandHandler<TestCommand, Unit>
   {
@@ -43,38 +43,52 @@ internal sealed class TestCommand : ICommand<Unit>
 
       string testsDirectory = Path.Combine(repoRoot, "tests");
 
-      if (!Directory.Exists(testsDirectory) || !Directory.EnumerateFiles(testsDirectory, "*.cs", SearchOption.AllDirectories).Any())
+      string[] testFiles = Directory.Exists(testsDirectory)
+        ? [.. Directory.GetFiles(testsDirectory, "*.cs", SearchOption.AllDirectories).Order(StringComparer.Ordinal)]
+        : [];
+
+      if (testFiles.Length == 0)
       {
         Terminal.WriteLine("No tests found. Skipping test step.");
         return Value;
       }
 
-      Terminal.WriteLine("Running TimeWarp.Builder tests...");
+      Terminal.WriteLine($"Running {testFiles.Length} Jaribu test file(s)...");
       Terminal.WriteLine($"Working from: {repoRoot}");
 
-      ShellBuilder testBuilder = Shell.Builder("dotnet")
-        .WithArguments("test", Path.Combine(repoRoot, "timewarp-builder.slnx"), "--verbosity", command.Verbose ? "normal" : "minimal");
+      int failedCount = 0;
 
-      if (command.NoBuild)
+      foreach (string testFile in testFiles)
       {
-        testBuilder = testBuilder.WithArguments("--no-build");
+        string relativePath = Path.GetRelativePath(repoRoot, testFile);
+        Terminal.WriteLine($"\n▶ {relativePath}");
+
+        ShellBuilder runBuilder = Shell.Builder("dotnet")
+          .WithArguments("run", testFile)
+          .WithNoValidation();
+
+        if (command.Filter is not null)
+        {
+          runBuilder = runBuilder.WithEnvironmentVariable("JARIBU_FILTER_TAG", command.Filter);
+        }
+
+        int exitCode = await runBuilder.RunAsync();
+
+        if (exitCode != 0)
+        {
+          failedCount++;
+          Terminal.WriteErrorLine($"❌ Failed: {relativePath}");
+        }
       }
 
-      if (command.Filter is not null)
+      if (failedCount > 0)
       {
-        testBuilder = testBuilder.WithArguments("--filter", command.Filter);
-      }
-
-      int exitCode = await testBuilder.WithNoValidation().RunAsync();
-
-      if (exitCode != 0)
-      {
-        Environment.ExitCode = exitCode;
-        Terminal.WriteErrorLine($"Tests failed with exit code {exitCode}");
+        Environment.ExitCode = 1;
+        Terminal.WriteErrorLine($"\n❌ {failedCount} of {testFiles.Length} test file(s) failed");
         return Value;
       }
 
-      Terminal.WriteLine("\n✅ Tests completed successfully!");
+      Terminal.WriteLine($"\n✅ All {testFiles.Length} test file(s) passed!");
       return Value;
     }
   }


### PR DESCRIPTION
## Summary

Closes out every v1.0.0 blocker and high-priority item from kanban task 001, and bumps the version to **1.0.0**.

### Tests (the last blocker)
- 21 TimeWarp.Jaribu runfile tests across 6 files under `tests/`
- Scope extensions: happy path, chaining, value-type semantics, and null-guard `ArgumentNullException` for `Also`, `Apply`, `Let`, `Run`
- Interfaces: concrete `IBuilder<T>` / `INestedBuilder<TParent>` implementations modeled on TimeWarp.Nuru's real builders, including `out` covariance assertions and a chain composing interfaces with scope extensions
- `dev test` rewired to execute runfiles and aggregate exit codes (previously ran `dotnet test` on a solution containing no test projects); `--filter` maps to `JARIBU_FILTER_TAG`
- CI's test step now genuinely gates the pipeline

### Readme
- NuGet/downloads/CI/license badges, installation, requirements (.NET 10, AOT/trim-safe), `Also` vs `Apply` design rationale, Used-By (nuru, terminal), testing instructions

### Code
- `#region Purpose`/`Design` context blocks on all library source files
- Removed all seven global `IL*` AOT warning suppressions — the library has no reflection; both the library build and dev-cli AOT publish verified clean without them
- Package bumps: TimeWarp.Amuru 1.0.0-beta.34, NetAnalyzers 10.0.301, Jaribu 1.0.0-beta.13 + Shouldly 4.3.0 (for tests)

## Test plan
- [x] `dev workflow --mode pr` — clean → build → 21 tests, exit 0
- [x] `dev format`, `ganda repo audit` (21/21), `dev check-version` (1.0.0 unpublished, ready)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)