### PR TITLE
Close v1.0.0 kanban task, split IBuildAsync to backlog task 005

### DIFF
--- a/kanban/backlog/005-add-ibuildasync-interface-for-async-build-scenarios.md
+++ b/kanban/backlog/005-add-ibuildasync-interface-for-async-build-scenarios.md
@@ -1,0 +1,34 @@
+# Add IBuildAsync interface for async build scenarios
+
+## Description
+
+Add an `IBuildAsync<TBuilt>` interface for builders whose build step is inherently asynchronous
+(for example, builders that resolve external resources or perform I/O when producing the object).
+
+Split out from task 001 (v1.0.0 release blockers) as a post-1.0 feature for a future v1.x.
+
+## Requirements
+
+- Design the shape: likely `ValueTask<TBuilt> BuildAsync(CancellationToken ct = default)` — note
+  that `out TBuilt` covariance (as on `IBuilder<TBuilt>`) does not compose with `ValueTask<TBuilt>`
+  returns, so the variance story needs a deliberate decision
+- Decide whether a nested counterpart (`INestedBuilderAsync<TParent>` / `DoneAsync()`) is warranted
+- Keep the library AOT/trim clean — no reflection
+- Non-breaking addition; no changes to existing interfaces
+
+## Checklist
+
+- [ ] Survey TimeWarp.Nuru / TimeWarp.Terminal for concrete async-build needs before committing to a shape
+- [ ] Design the interface (variance, ValueTask vs Task, CancellationToken)
+- [ ] Implement with XML docs and Purpose/Design regions
+- [ ] Add Jaribu tests under tests/
+- [ ] Update readme
+
+## Notes
+
+Deferred from the v1.0.0 release (task 001, shipped 2026-07-02) because no current consumer
+needed it; adding it later is non-breaking.
+
+## Session
+
+- Created: 2026-07-02 (split from task 001 during the v1.0.0 release session)

--- a/kanban/done/001-address-code-review-blockers-for-v100-release.md
+++ b/kanban/done/001-address-code-review-blockers-for-v100-release.md
@@ -79,8 +79,8 @@ Code review report: `.agent/workspace/2026-02-23T00-00-00_code-review-release-re
 ### Nice to Have (low priority)
 
 - [x] Add `#region Purpose` / `#region Design` context blocks to source files per csharp skill conventions (2026-07-02)
-- [ ] Add `CHANGELOG.md` for v1.0.0 release notes
-- [ ] Consider `IBuildAsync<T>` interface for async build scenarios (future v1.x)
+- [x] ~~Add `CHANGELOG.md` for v1.0.0 release notes~~ — decided not needed (2026-07-02); GitHub release notes serve this purpose
+- [x] Consider `IBuildAsync<T>` interface for async build scenarios — split out to backlog task 005 (2026-07-02)
 
 ## Notes
 


### PR DESCRIPTION
Kanban housekeeping after the v1.0.0 release:

- Task 001 (v1.0.0 blockers) → done; all blockers shipped in v1.0.0
- CHANGELOG.md nice-to-have marked as not needed — GitHub release notes serve that purpose
- IBuildAsync<T> split out to new backlog task 005 with design notes (variance vs ValueTask, nested counterpart question, survey consumers first)

Kanban-only change; no CI paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)